### PR TITLE
update KDE runtime to 5.14

### DIFF
--- a/de.unifreiburg.ellipticcurve.json
+++ b/de.unifreiburg.ellipticcurve.json
@@ -1,7 +1,7 @@
 {
     "app-id": "de.unifreiburg.ellipticcurve",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.13",
+    "runtime-version": "5.14",
     "sdk": "org.kde.Sdk",
     "command": "ellipticcurve",
     "finish-args": [


### PR DESCRIPTION
~~Also set `run-tests` to **true**.~~
This was build and tested successfully with `flatpak-builder 1.0.9`.

Edit: flathubbot doesn't like `run-tests` in manifest.
Edit2: it's a flatpak-builder bug: https://github.com/flatpak/flatpak-builder/issues/229